### PR TITLE
Constant completion

### DIFF
--- a/lib/yoda/evaluation.rb
+++ b/lib/yoda/evaluation.rb
@@ -3,7 +3,7 @@ module Yoda
     require 'yoda/evaluation/evaluator'
     require 'yoda/evaluation/current_node_explain'
     require 'yoda/evaluation/comment_completion'
-    require 'yoda/evaluation/method_completion'
+    require 'yoda/evaluation/code_completion'
     require 'yoda/evaluation/signature_discovery'
   end
 end

--- a/lib/yoda/evaluation/code_completion.rb
+++ b/lib/yoda/evaluation/code_completion.rb
@@ -1,6 +1,6 @@
 module Yoda
   module Evaluation
-    class MethodCompletion
+    class CodeCompletion
       # @return [Store::Registry]
       attr_reader :registry
 

--- a/lib/yoda/evaluation/code_completion.rb
+++ b/lib/yoda/evaluation/code_completion.rb
@@ -1,6 +1,11 @@
 module Yoda
   module Evaluation
     class CodeCompletion
+      require 'yoda/evaluation/code_completion/base_provider'
+      require 'yoda/evaluation/code_completion/method_provider'
+      require 'yoda/evaluation/code_completion/variable_provider'
+      require 'yoda/evaluation/code_completion/const_provider'
+
       # @return [Store::Registry]
       attr_reader :registry
 
@@ -21,77 +26,39 @@ module Yoda
 
       # @return [true, false]
       def valid?
-        !!(current_send)
+        providers.any?(&:providable?)
       end
 
-      # @return [Array<Store::Objects::Method>]
-      def method_candidates
-        return [] unless valid?
-        receiver_values
-          .map { |value| Store::Query::FindSignature.new(registry).select(value, /\A#{Regexp.escape(index_word)}/, visibility: method_visibility_of_send_node(current_send)) }
-          .flatten
-      end
-
-      # @return [Range, nil]
-      def substitution_range
-        return nil unless valid?
-        return current_send.selector_range if current_send.on_selector?(location)
-        return Parsing::Range.new(current_send.next_location_to_dot, current_send.next_location_to_dot) if current_send.on_dot?(location)
-        nil
+      # @return [Array<Model::CompletionItem>]
+      def candidates
+        providers.select(&:providable?).map(&:candidates).flatten
       end
 
       private
 
-      # @param send_node [Parsing::NodeObjects::SendNode]
-      # @return [Array<Symbol>]
-      def method_visibility_of_send_node(send_node)
-        if send_node.receiver_node
-          %i(public)
-        else
-          %i(public private protected)
-        end
+      # @return [Array<CodeCompletion::BaseProvider>]
+      def providers
+        [method_provider, variable_provider, const_provider]
       end
 
-      # @return [Array<Store::Objects::Base>]
-      def receiver_values
-        @receiver_values ||= begin
-          if current_receiver_node
-            evaluator.calculate_values(current_receiver_node)
-          else
-            # implicit call for self
-            [evaluator.scope_constant]
-          end
-        end
+      # @return [Parsing::SourceAnalyzer]
+      def source_analyzer
+        @source_analyzer ||= Parsing::SourceAnalyzer.from_source(source, location)
       end
 
-      # @return [Parsing::NodeObjects::SendNode, nil]
-      def current_send
-        @current_send ||= begin
-          node = analyzer.nodes_to_current_location_from_root.last
-          return nil unless node.type == :send
-          Parsing::NodeObjects::SendNode.new(node)
-        end
+      # @return [MethodProvider]
+      def method_provider
+        @method_provider ||= MethodProvider.new(registry, source_analyzer)
       end
 
-      # @return [SourceAnalyzer]
-      def analyzer
-        @analyzer ||= Parsing::SourceAnalyzer.from_source(source, location)
+      # @return [VariableProvider]
+      def variable_provider
+        @variable_provider ||= VariableProvider.new(registry, source_analyzer)
       end
 
-      # @return [Parser::AST::Node, nil]
-      def current_receiver_node
-        current_send&.receiver_node
-      end
-
-      # @return [String, nil]
-      def index_word
-        return nil unless valid?
-        @index_word ||= current_send.on_selector?(location) ? current_send.selector_name.slice(0..current_send.offset_in_selector(location)) : ''
-      end
-
-      # @return [Evaluator]
-      def evaluator
-        @evaluator ||= Evaluator.from_ast(registry, analyzer.ast, location)
+      # @return [ConstantProvider]
+      def const_provider
+        @constant_provider ||= ConstProvider.new(registry, source_analyzer)
       end
     end
   end

--- a/lib/yoda/evaluation/code_completion/base_provider.rb
+++ b/lib/yoda/evaluation/code_completion/base_provider.rb
@@ -1,0 +1,57 @@
+module Yoda
+  module Evaluation
+    class CodeCompletion
+      # @abstract
+      # Base class of completion candidates providers for code completion.
+      # This class bridges analysis features such as syntastic analysis {#analyzer} and symbolic execiton {#evaluator}.
+      class BaseProvider
+        # @return [Store::Registry]
+        attr_reader :registry
+
+        # @return [Parsing::SourceAnalyzer]
+        attr_reader :source_analyzer
+
+        # @param registry [Store::Registry]
+        # @param source_analyzer [Parsing::SourceAnalyzer]
+        def initialize(registry, source_analyzer)
+          @registry = registry
+          @source_analyzer = source_analyzer
+        end
+
+        # @abstract
+        # @return [true, false]
+        def providable?
+          fail NotImplementedError
+        end
+
+        # @abstract
+        # @return [Array<Model::CompletionItem>]
+        def candidates
+          fail NotImplementedError
+        end
+
+        private
+
+        # @return [SourceAnalyzer]
+        def analyzer
+          @analyzer ||= Parsing::SourceAnalyzer.from_source(source, location)
+        end
+
+        # @return [Evaluator]
+        def evaluator
+          @evaluator ||= Evaluator.from_ast(registry, source_analyzer.ast, location)
+        end
+
+        # @return [::Parser::AST::Node]
+        def ast
+          source_analyzer.ast
+        end
+
+        # @return [Parsing::Location]
+        def location
+          source_analyzer.location
+        end
+      end
+    end
+  end
+end

--- a/lib/yoda/evaluation/code_completion/const_provider.rb
+++ b/lib/yoda/evaluation/code_completion/const_provider.rb
@@ -1,0 +1,17 @@
+module Yoda
+  module Evaluation
+    class CodeCompletion
+      class ConstProvider < BaseProvider
+        # @return [true, false]
+        def providable?
+          false
+        end
+
+        # @return [Array<Model::CompletionItem>]
+        def candidates
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/yoda/evaluation/code_completion/const_provider.rb
+++ b/lib/yoda/evaluation/code_completion/const_provider.rb
@@ -4,12 +4,61 @@ module Yoda
       class ConstProvider < BaseProvider
         # @return [true, false]
         def providable?
-          false
+          !!current_const
         end
 
-        # @return [Array<Model::CompletionItem>]
+        # Returns constant candidates by using the current lexical scope.
+        # @return [Array<Model::CompletionItem>] constant candidates.
         def candidates
-          []
+          const_candidates.map do |const_candidate|
+            Model::CompletionItem.new(
+              description: Model::Descriptions::ValueDescription.new(const_candidate),
+              range: substitution_range,
+            )
+          end
+        end
+
+        private
+
+        # @return [Range]
+        def substitution_range
+          return nil unless current_const
+          Parsing::Range.of_ast_location(current_const.node.location.name)
+        end
+
+        # @return [Parsing::NodeObjects::ConstNode, nil]
+        def current_const
+          @current_const ||= begin
+            node = source_analyzer.nodes_to_current_location_from_root.reverse.take_while { |el| el.type == :const }.last
+            return nil unless node
+            Parsing::NodeObjects::ConstNode.new(node)
+          end
+        end
+
+        # @return [Array<Objects::Base>]
+        def const_candidates
+          return [] unless providable?
+          return [] if const_parent_paths.empty?
+          scoped_path = Model::ScopedPath.new(const_parent_paths, current_const.to_s)
+          Store::Query::FindConstant.new(registry).select_with_prefix(scoped_path)
+        end
+
+        # @return [Parsing::ConstNode]
+        def const_parent
+          current_const && current_const.parent_const
+        end
+
+        # @return [Array<Store::Objects::Base>]
+        def const_parent_paths
+          @const_parent_pathss ||= begin
+            lexical_scope(source_analyzer.current_namespace)
+          end
+        end
+
+        # @param namespace [Parsing::NodeObjects::Namespace]
+        # @return [Array<Path>]
+        def lexical_scope(namespace)
+          namespace.paths_from_root.reverse.map { |name| Model::Path.build(name.empty? ? 'Object' : name.gsub(/\A::/, '')) }
         end
       end
     end

--- a/lib/yoda/evaluation/code_completion/method_provider.rb
+++ b/lib/yoda/evaluation/code_completion/method_provider.rb
@@ -1,0 +1,81 @@
+module Yoda
+  module Evaluation
+    class CodeCompletion
+      class MethodProvider < BaseProvider
+        # @return [true, false]
+        def providable?
+          !!(current_send)
+        end
+
+        # @return [Array<Model::CompletionItem>]
+        def candidates
+          method_candidates.map do |method_candidate|
+            Model::CompletionItem.new(
+              description: Model::Descriptions::FunctionDescription.new(method_candidate),
+              range: substitution_range,
+            )
+          end
+        end
+
+        private
+
+        # @return [Range]
+        def substitution_range
+          return current_send.selector_range if current_send.on_selector?(location)
+          return Parsing::Range.new(current_send.next_location_to_dot, current_send.next_location_to_dot) if current_send.on_dot?(location)
+          nil
+        end
+
+        # @return [Array<Store::Objects::Method>]
+        def method_candidates
+          return [] unless providable?
+          receiver_values
+            .map { |value| Store::Query::FindSignature.new(registry).select(value, /\A#{Regexp.escape(index_word)}/, visibility: method_visibility_of_send_node(current_send)) }
+            .flatten
+        end
+
+        # @param send_node [Parsing::NodeObjects::SendNode]
+        # @return [Array<Symbol>]
+        def method_visibility_of_send_node(send_node)
+          if send_node.receiver_node
+            %i(public)
+          else
+            %i(public private protected)
+          end
+        end
+
+        # @return [Array<Store::Objects::Base>]
+        def receiver_values
+          @receiver_values ||= begin
+            if current_receiver_node
+              evaluator.calculate_values(current_receiver_node)
+            else
+              # implicit call for self
+              [evaluator.scope_constant]
+            end
+          end
+        end
+
+        # @return [Parsing::NodeObjects::SendNode, nil]
+        def current_send
+          @current_send ||= begin
+            node = source_analyzer.nodes_to_current_location_from_root.last
+            return nil unless node.type == :send
+            Parsing::NodeObjects::SendNode.new(node)
+          end
+        end
+
+        # @return [Parser::AST::Node, nil]
+        def current_receiver_node
+          current_send&.receiver_node
+        end
+
+        # @return [String, nil]
+        def index_word
+          return nil unless providable?
+          @index_word ||= current_send.on_selector?(location) ? current_send.selector_name.slice(0..current_send.offset_in_selector(location)) : ''
+        end
+      end
+    end
+  end
+end

--- a/lib/yoda/evaluation/code_completion/variable_provider.rb
+++ b/lib/yoda/evaluation/code_completion/variable_provider.rb
@@ -1,0 +1,18 @@
+module Yoda
+  module Evaluation
+    class CodeCompletion
+      # WIP
+      class VariableProvider < BaseProvider
+        # @return [true, false]
+        def providable?
+          false
+        end
+
+        # @return [Array<Model::CompletionItem>]
+        def candidates
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/yoda/evaluation/comment_completion.rb
+++ b/lib/yoda/evaluation/comment_completion.rb
@@ -29,8 +29,15 @@ module Yoda
         !!(current_comment_query.current_comment && current_comment_token_query.current_word)
       end
 
-      # @return [Array<Model::Descriptions::Base>]
+      # @return [Array<Model::CompletionItem>]
       def candidates
+        description_candidates.map { |description| Model::CompletionItem.new(description: description, range: substitution_range) }
+      end
+
+      private
+
+      # @return [Array<Model::Descriptions::Base>]
+      def description_candidates
         return [] unless valid?
         case current_comment_token_query.current_state
         when :tag
@@ -68,8 +75,6 @@ module Yoda
           )
         end
       end
-
-      private
 
       def param_candidates
         []

--- a/lib/yoda/model.rb
+++ b/lib/yoda/model.rb
@@ -7,5 +7,6 @@ module Yoda
     require 'yoda/model/scoped_path'
     require 'yoda/model/types'
     require 'yoda/model/values'
+    require 'yoda/model/completion_item'
   end
 end

--- a/lib/yoda/model/completion_item.rb
+++ b/lib/yoda/model/completion_item.rb
@@ -1,0 +1,22 @@
+module Yoda
+  module Model
+    class CompletionItem
+      # @return [Descriptions::Base]
+      attr_reader :description
+
+      # @return [Parsing::Range]
+      attr_reader :range
+
+      # @param description [Descriptions::Base]
+      # @param range [Parsing::Range]
+      def initialize(description:, range:)
+        fail ArgumentError, desctiption unless description.is_a?(Descriptions::Base)
+        fail ArgumentError, range unless range.is_a?(Parsing::Range)
+        @description = description
+        @range = range
+      end
+
+
+    end
+  end
+end

--- a/lib/yoda/parsing/node_objects/const_node.rb
+++ b/lib/yoda/parsing/node_objects/const_node.rb
@@ -2,12 +2,22 @@ module Yoda
   module Parsing
     module NodeObjects
       class ConstNode
+        # @param node [::AST::Node]
         attr_reader :node
 
         # @param node [::AST::Node]
         def initialize(node)
           fail ArgumentError, node unless node.is_a?(::AST::Node) && node.type == :const
           @node = node
+        end
+
+        # @return [ConstNode, nil]
+        def parent_const
+          node.children.first && node.children.first.type == :const ? ConstNode.new(node.children.first) : nil
+        end
+
+        def basename
+          parent_const ? ConstNode.new(node.children.last).to_s : to_s
         end
 
         # @param base [String, Symbol, nil]

--- a/lib/yoda/server/completion_provider.rb
+++ b/lib/yoda/server/completion_provider.rb
@@ -31,11 +31,10 @@ module Yoda
         return nil unless Parsing::Query::CurrentCommentQuery.new(comments, location).current_comment
         completion_worker = Evaluation::CommentCompletion.new(client_info.registry, ast, comments, location)
         return nil unless completion_worker.valid?
-        range = completion_worker.substitution_range
 
         LSP::Interface::CompletionList.new(
           is_incomplete: false,
-          items: completion_worker.candidates.map { |description| create_completion_item(description, range) },
+          items: completion_worker.candidates.map { |completion_item| create_completion_item(completion_item) },
         )
       rescue ::Parser::SyntaxError
         nil
@@ -47,28 +46,27 @@ module Yoda
       def complete_from_cut_source(source, location)
         cut_source = Parsing::SourceCutter.new(source, location).error_recovered_source
         method_completion_worker = Evaluation::CodeCompletion.new(client_info.registry, cut_source, location)
-        functions = method_completion_worker.method_candidates
-        range = method_completion_worker.substitution_range
-        return nil unless range
+        completion_items = method_completion_worker.candidates
+        return nil if completion_items.empty?
 
         LSP::Interface::CompletionList.new(
           is_incomplete: false,
-          items: functions.map { |function| create_completion_item(Model::Descriptions::FunctionDescription.new(function), range) },
+          items: completion_items.map { |completion_item| create_completion_item(completion_item) },
         )
       end
 
-      # @param description [Model::Descriptions::Base]
-      # @param range       [Parsing::Range]
-      def create_completion_item(description, range)
+      # @param completion_item [Model::CompletionItem]
+      # @return            [LSP::Interface::CompletionItem]
+      def create_completion_item(completion_item)
         LSP::Interface::CompletionItem.new(
-          label: description.is_a?(Model::Descriptions::FunctionDescription) ? description.signature : description.sort_text,
+          label: completion_item.description.is_a?(Model::Descriptions::FunctionDescription) ? completion_item.description.signature : completion_item.description.sort_text,
           kind: LSP::Constant::CompletionItemKind::METHOD,
-          detail: description.title,
-          documentation: description.to_markdown,
-          sort_text: description.sort_text,
+          detail: completion_item.description.title,
+          documentation: completion_item.description.to_markdown,
+          sort_text: completion_item.description.sort_text,
           text_edit: LSP::Interface::TextEdit.new(
-            range: LSP::Interface::Range.new(range.to_language_server_protocol_range),
-            new_text: description.sort_text,
+            range: LSP::Interface::Range.new(completion_item.range.to_language_server_protocol_range),
+            new_text: completion_item.description.sort_text,
           ),
           data: {},
         )

--- a/lib/yoda/server/completion_provider.rb
+++ b/lib/yoda/server/completion_provider.rb
@@ -46,7 +46,7 @@ module Yoda
       # @return [LanguageServerProtocol::Interface::CompletionList, nil]
       def complete_from_cut_source(source, location)
         cut_source = Parsing::SourceCutter.new(source, location).error_recovered_source
-        method_completion_worker = Evaluation::MethodCompletion.new(client_info.registry, cut_source, location)
+        method_completion_worker = Evaluation::CodeCompletion.new(client_info.registry, cut_source, location)
         functions = method_completion_worker.method_candidates
         range = method_completion_worker.substitution_range
         return nil unless range

--- a/spec/support/fixtures/lib/const_completion_fixture.rb
+++ b/spec/support/fixtures/lib/const_completion_fixture.rb
@@ -1,0 +1,20 @@
+module YodaFixture
+  class ConstCompletionFixture
+    # @param content [String]
+    def initialize(content)
+      @content = content
+      @contents = [content]
+    end
+
+    def method1
+      ConstCompletionFixture
+      ::ConstCompletionFixture
+      ::YodaFixture
+      YodaFixture::ConstCompletionFixture
+      YodaFixture::YodaInnerModule
+    end
+  end
+
+  module YodaInnerModule
+  end
+end

--- a/spec/support/fixtures/lib/evaluator_spec_fixture2.rb
+++ b/spec/support/fixtures/lib/evaluator_spec_fixture2.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module YodaFixture
+  class EvaluatorSpecFixture2
+  end
+end

--- a/spec/yoda/evaluation/code_completion_spec.rb
+++ b/spec/yoda/evaluation/code_completion_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.xdescribe Yoda::Evaluation::MethodCompletion do
+RSpec.xdescribe Yoda::Evaluation::CodeCompletion do
   include TypeHelper
 
   let(:registry) { Yoda::Store::Registry.instance }

--- a/spec/yoda/parsing/source_analyzer_spec.rb
+++ b/spec/yoda/parsing/source_analyzer_spec.rb
@@ -8,23 +8,44 @@ RSpec.describe Yoda::Parsing::SourceAnalyzer do
     subject { described_class.from_source(source, location).nodes_to_current_location_from_root }
 
     context 'a class definition is given' do
-      let(:location) { Yoda::Parsing::Location.new(row: 3, column: 9) }
       let(:source) do
         <<~EOS
         class Hoge
           def main(hoge)
             hoge.fu
           end
+
+          def main2
+            ConstName
+          end
         end
         EOS
       end
 
-      it 'returns the type of the method' do
-        expect(subject).to match([
-          have_attributes(type: :class),
-          have_attributes(type: :def, children: include(:main)),
-          have_attributes(type: :send, children: include(:fu)),
-        ])
+      context 'when the cursor is on a send node' do
+        let(:location) { Yoda::Parsing::Location.new(row: 3, column: 9) }
+
+        it 'returns the type of the method' do
+          expect(subject).to match([
+            have_attributes(type: :class),
+            have_attributes(type: :begin),
+            have_attributes(type: :def, children: include(:main)),
+            have_attributes(type: :send, children: include(:fu)),
+          ])
+        end
+      end
+
+      context 'when the cursor is on a single const node' do
+        let(:location) { Yoda::Parsing::Location.new(row: 7, column: 9) }
+
+        it 'returns the type of the method' do
+          expect(subject).to match([
+            have_attributes(type: :class),
+            have_attributes(type: :begin),
+            have_attributes(type: :def, children: include(:main2)),
+            have_attributes(type: :const, children: include(:ConstName)),
+          ])
+        end
       end
     end
   end

--- a/spec/yoda/server/completion_provider_spec.rb
+++ b/spec/yoda/server/completion_provider_spec.rb
@@ -103,6 +103,72 @@ RSpec.describe Yoda::Server::CompletionProvider do
       end
     end
 
+    describe 'const completion' do
+      let(:uri) { file_uri('lib/const_completion_fixture.rb') }
+
+      context 'when the cursor is in an instance method' do
+        context 'and the const node is single constant without cbase' do
+          let(:position) { { line: 9, character: 15 } }
+          let(:text_edit_range) { { start: { line: 9, character: 6 }, end: { line: 9, character: 28 } } }
+
+          it 'returns infomation including appropriate labels' do
+            expect(subject).to be_a(LSP::Interface::CompletionList)
+            expect(subject.is_incomplete).to be_falsy
+            expect(subject.items).to include(
+              have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+            )
+          end
+        end
+
+        context 'and the const node is single constant with cbase which does not exist' do
+          let(:position) { { line: 10, character: 15 } }
+
+          it 'returns empty candidates' do
+            expect(subject).to be_falsy
+          end
+        end
+
+        context 'and the const node is single constant with cbase' do
+          let(:position) { { line: 11, character: 15 } }
+          let(:text_edit_range) { { start: { line: 11, character: 8 }, end: { line: 11, character: 19 } } }
+
+          it 'returns infomation including appropriate labels' do
+            expect(subject).to be_a(LSP::Interface::CompletionList)
+            expect(subject.is_incomplete).to be_falsy
+            expect(subject.items).to include(
+              have_attributes(label: 'YodaFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+            )
+          end
+        end
+
+        context 'and the const node is single constant with cbase' do
+          let(:position) { { line: 12, character: 30 } }
+          let(:text_edit_range) { { start: { line: 12, character: 19 }, end: { line: 12, character: 41 } } }
+
+          it 'returns infomation including appropriate labels' do
+            expect(subject).to be_a(LSP::Interface::CompletionList)
+            expect(subject.is_incomplete).to be_falsy
+            expect(subject.items).to include(
+              have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+            )
+          end
+        end
+
+        context 'and there are constants with the common prefix of the const name but in different namespace' do
+          let(:position) { { line: 13, character: 23 } }
+          let(:text_edit_range) { { start: { line: 13, character: 19 }, end: { line: 13, character: 34 } } }
+
+          it 'returns candidates of constants without ones in different namespace' do
+            expect(subject).to be_a(LSP::Interface::CompletionList)
+            expect(subject.is_incomplete).to be_falsy
+            expect(subject.items).to contain_exactly(
+              have_attributes(label: 'YodaInnerModule', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+            )
+          end
+        end
+      end
+    end
+
     describe 'comment completion' do
       describe 'tag completion' do
         context 'request on a sample function' do


### PR DESCRIPTION
## WHAT

- Provide constant candidates on code completion
   - Complete from current lexical scope and don't use symbolic execution
       - Constant address with variable (such as `some_variable::CONSTANT_NAME`) are currently not supported
- Refactor `Evaluation::MethodCompletion`
   - Introduce `CodeCompletion::BaseProvider` and method candidates are provided by `CodeCompletion::MethodProvider`
- Add a missing fixture file
