### PR TITLE
Support Constant Completion just after `::`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     yoda (0.2.0)
-      language_server-protocol (~> 0.5)
+      language_server-protocol (~> 3.7.0.0)
       leveldb (~> 0.1.9)
       lmdb (~> 0.4.8)
       parser (~> 2.0)
@@ -22,12 +22,12 @@ GEM
     diff-lcs (1.3)
     fiddler-rb (0.1.2)
     interception (0.5)
-    language_server-protocol (0.5.0)
+    language_server-protocol (3.7.0.0)
     leveldb (0.1.9)
       fiddler-rb (~> 0.1.1)
     lmdb (0.4.8)
     method_source (0.9.0)
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pry (0.11.3)
@@ -58,7 +58,7 @@ GEM
     rspec-support (3.7.1)
     ruby-progressbar (1.9.0)
     stackprof (0.2.11)
-    yard (0.9.12)
+    yard (0.9.14)
 
 PLATFORMS
   ruby

--- a/lib/yoda/evaluation/code_completion/const_provider.rb
+++ b/lib/yoda/evaluation/code_completion/const_provider.rb
@@ -14,12 +14,26 @@ module Yoda
             Model::CompletionItem.new(
               description: Model::Descriptions::ValueDescription.new(const_candidate),
               range: substitution_range,
+              kind: complete_item_kind(const_candidate),
               prefix: just_after_separator? ? '::' : '',
             )
           end
         end
 
         private
+
+        # @param object [Store::Objects::Base]
+        # @return [Symbol]
+        def complete_item_kind(object)
+          case object.kind
+          when :class
+            :class
+          when :module
+            :module
+          else
+            :constant
+          end
+        end
 
         # @return [Range, nil]
         def substitution_range

--- a/lib/yoda/evaluation/code_completion/const_provider.rb
+++ b/lib/yoda/evaluation/code_completion/const_provider.rb
@@ -20,7 +20,7 @@ module Yoda
 
         private
 
-        # @return [Range]
+        # @return [Range, nil]
         def substitution_range
           return nil unless current_const
           Parsing::Range.of_ast_location(current_const.node.location.name)
@@ -50,7 +50,7 @@ module Yoda
 
         # @return [Array<Store::Objects::Base>]
         def const_parent_paths
-          @const_parent_pathss ||= begin
+          @const_parent_paths ||= begin
             lexical_scope(source_analyzer.current_namespace)
           end
         end

--- a/lib/yoda/evaluation/code_completion/method_provider.rb
+++ b/lib/yoda/evaluation/code_completion/method_provider.rb
@@ -13,6 +13,7 @@ module Yoda
             Model::CompletionItem.new(
               description: Model::Descriptions::FunctionDescription.new(method_candidate),
               range: substitution_range,
+              kind: :method,
             )
           end
         end

--- a/lib/yoda/model/completion_item.rb
+++ b/lib/yoda/model/completion_item.rb
@@ -7,15 +7,24 @@ module Yoda
       # @return [Parsing::Range]
       attr_reader :range
 
+      # @return [String]
+      attr_reader :prefix
+
       # @param description [Descriptions::Base]
-      # @param range [Parsing::Range]
-      def initialize(description:, range:)
+      # @param range       [Parsing::Range]
+      # @param prefix      [String, nil]
+      def initialize(description:, range:, prefix: nil)
         fail ArgumentError, desctiption unless description.is_a?(Descriptions::Base)
         fail ArgumentError, range unless range.is_a?(Parsing::Range)
         @description = description
         @range = range
+        @prefix = prefix || ''
       end
 
+      # @return [String]
+      def edit_text
+        prefix + description.sort_text
+      end
 
     end
   end

--- a/lib/yoda/model/completion_item.rb
+++ b/lib/yoda/model/completion_item.rb
@@ -7,17 +7,23 @@ module Yoda
       # @return [Parsing::Range]
       attr_reader :range
 
+      # @return [Symbol]
+      attr_reader :kind
+
       # @return [String]
       attr_reader :prefix
 
       # @param description [Descriptions::Base]
       # @param range       [Parsing::Range]
+      # @param kind        [Symbol, nil]
       # @param prefix      [String, nil]
-      def initialize(description:, range:, prefix: nil)
+      def initialize(description:, range:, kind: nil, prefix: nil)
         fail ArgumentError, desctiption unless description.is_a?(Descriptions::Base)
         fail ArgumentError, range unless range.is_a?(Parsing::Range)
+        fail ArgumentError, kind if !kind.nil? && !available_kinds.include?(kind)
         @description = description
         @range = range
+        @kind = kind
         @prefix = prefix || ''
       end
 
@@ -26,6 +32,25 @@ module Yoda
         prefix + description.sort_text
       end
 
+      # @return [Symbol]
+      def available_kinds
+        %i(method class module constant)
+      end
+
+      def language_server_kind
+        case kind
+        when :constant
+          LanguageServer::Protocol::Constant::CompletionItemKind::VALUE
+        when :method
+          LanguageServer::Protocol::Constant::CompletionItemKind::METHOD
+        when :class
+          LanguageServer::Protocol::Constant::CompletionItemKind::CLASS
+        when :module
+          LanguageServer::Protocol::Constant::CompletionItemKind::MODULE
+        else
+          nil
+        end
+      end
     end
   end
 end

--- a/lib/yoda/model/path.rb
+++ b/lib/yoda/model/path.rb
@@ -9,6 +9,12 @@ module Yoda
         path.is_a?(Path) ? path : new(path)
       end
 
+      # @param names [Array<Path, String>]
+      # @return [Path]
+      def self.from_names(names)
+        new(names.join('::'))
+      end
+
       # @param name [String]
       def initialize(name)
         fail ArgumentError, name unless name.is_a?(String)

--- a/lib/yoda/parsing/location.rb
+++ b/lib/yoda/parsing/location.rb
@@ -90,7 +90,7 @@ module Yoda
       end
 
       # @param another [Location]
-      # @return Integer
+      # @return [Integer]
       def <=>(another)
         return 0 if row == another.row && column == another.column
         return 1 if (row == another.row && column >= another.column) || row > another.row

--- a/lib/yoda/parsing/node_objects/const_node.rb
+++ b/lib/yoda/parsing/node_objects/const_node.rb
@@ -16,8 +16,9 @@ module Yoda
           node.children.first && node.children.first.type == :const ? ConstNode.new(node.children.first) : nil
         end
 
-        def basename
-          parent_const ? ConstNode.new(node.children.last).to_s : to_s
+        # @return [true, false]
+        def absolute?
+          node.children.first == :cbase
         end
 
         # @param location [Location]
@@ -25,6 +26,11 @@ module Yoda
         def just_after_separator?(location)
           return false unless node.location.double_colon
           location == Location.of_ast_location(node.location.double_colon.end)
+        end
+
+        # @return [Model::Path]
+        def to_path
+          Model::Path.new(to_s)
         end
 
         # @param base [String, Symbol, nil]

--- a/lib/yoda/parsing/node_objects/const_node.rb
+++ b/lib/yoda/parsing/node_objects/const_node.rb
@@ -20,6 +20,13 @@ module Yoda
           parent_const ? ConstNode.new(node.children.last).to_s : to_s
         end
 
+        # @param location [Location]
+        # @return [true, false]
+        def just_after_separator?(location)
+          return false unless node.location.double_colon
+          location == Location.of_ast_location(node.location.double_colon.end)
+        end
+
         # @param base [String, Symbol, nil]
         # @return [String]
         def to_s(base = nil)

--- a/lib/yoda/parsing/source_cutter.rb
+++ b/lib/yoda/parsing/source_cutter.rb
@@ -138,7 +138,7 @@ module Yoda
           when :tEQL, :tAMPER2, :tPIPE, :tBANG, :tCARET, :tPLUS, :tMINUS, :tSTAR2, :tDIVIDE, :tPERCENT, :tTILDE, :tCOMMA, :tDOT2, :tDOT3, :tCOLON,
               :tANDOP, :tOROP, :tUMINUS, :tUPLUS, :tTILDE, :tPOW, :tMATCH, :tNMATCH, :tEQ, :tNEQ, :tGT, :tRSHFT, :tGEQ, :tLT, :tLSHFT, :tLEQ, :tASSOC, :tEQQ, :tCMP, :tBANG, :tANDDOT
             :kNIL
-          when :tCOLON2
+          when :tCOLON2, :tCOLON3
             :dummy_constant
           when :tDOT
             :dummy_method

--- a/lib/yoda/server/completion_provider.rb
+++ b/lib/yoda/server/completion_provider.rb
@@ -68,7 +68,7 @@ module Yoda
           sort_text: completion_item.description.sort_text,
           text_edit: LSP::Interface::TextEdit.new(
             range: LSP::Interface::Range.new(completion_item.range.to_language_server_protocol_range),
-            new_text: completion_item.description.sort_text,
+            new_text: completion_item.edit_text,
           ),
           data: {},
         )

--- a/lib/yoda/server/completion_provider.rb
+++ b/lib/yoda/server/completion_provider.rb
@@ -62,7 +62,7 @@ module Yoda
       def create_completion_item(completion_item)
         LSP::Interface::CompletionItem.new(
           label: completion_item.description.is_a?(Model::Descriptions::FunctionDescription) ? completion_item.description.signature : completion_item.description.sort_text,
-          kind: LSP::Constant::CompletionItemKind::METHOD,
+          kind: completion_item.language_server_kind,
           detail: completion_item.description.title,
           documentation: completion_item.description.to_markdown,
           sort_text: completion_item.description.sort_text,

--- a/lib/yoda/server/completion_provider.rb
+++ b/lib/yoda/server/completion_provider.rb
@@ -31,7 +31,7 @@ module Yoda
         return nil unless Parsing::Query::CurrentCommentQuery.new(comments, location).current_comment
         completion_worker = Evaluation::CommentCompletion.new(client_info.registry, ast, comments, location)
         return nil unless completion_worker.available?
-        
+
         completion_items = completion_worker.candidates
 
         LSP::Interface::CompletionList.new(

--- a/lib/yoda/store/query/find_constant.rb
+++ b/lib/yoda/store/query/find_constant.rb
@@ -128,7 +128,7 @@ module Yoda
           when Model::ScopedPath
             path.path
           when String
-            Model::Path.new(path.gsub(/\A::/, ''))
+            Model::Path.new(path == '::' ? '::' : path.gsub(/\A::/, ''))
           else
             fail ArgumentError, path
           end

--- a/spec/yoda/parsing/source_cutter_spec.rb
+++ b/spec/yoda/parsing/source_cutter_spec.rb
@@ -57,8 +57,45 @@ RSpec.describe Yoda::Parsing::SourceCutter do
       end
     end
 
+    context 'cut on cbase or double colon' do
+      subject { described_class.new(source, location).error_recovered_source }
+      let(:source) do
+        <<~EOS
+        ::Const::Name
+        EOS
+      end
+
+      context 'on cbase' do
+        let(:location) { Yoda::Parsing::Location.new(row: 1, column: 2) }
+
+        it 'supplies DUMMY_CONSTANT after cbase' do
+          expect(subject).to eq(
+            <<~EOS.chomp
+            ::
+            DUMMY_CONSTANT
+            ;
+            EOS
+          )
+        end
+      end
+
+      context 'on double colon' do
+        let(:location) { Yoda::Parsing::Location.new(row: 1, column: 9) }
+
+        it 'supplies DUMMY_CONSTANT after cbase' do
+          expect(subject).to eq(
+            <<~EOS.chomp
+            ::Const::
+            DUMMY_CONSTANT
+            ;
+            EOS
+          )
+        end
+      end
+    end
+
     context 'cut on dot' do
-      subject { require 'pry'; Pry::rescue{ described_class.new(source, location).error_recovered_source } }
+      subject { described_class.new(source, location).error_recovered_source }
       let(:location) { Yoda::Parsing::Location.new(row: 32, column: 10) }
       let(:source) do
         <<~EOS

--- a/spec/yoda/server/completion_provider_spec.rb
+++ b/spec/yoda/server/completion_provider_spec.rb
@@ -107,32 +107,73 @@ RSpec.describe Yoda::Server::CompletionProvider do
       let(:uri) { file_uri('lib/const_completion_fixture.rb') }
 
       context 'when the cursor is in an instance method' do
-        context 'and the const node is single constant without cbase' do
-          let(:position) { { line: 9, character: 15 } }
-          let(:text_edit_range) { { start: { line: 9, character: 6 }, end: { line: 9, character: 28 } } }
+        context 'and the cursor is on a constant name' do
+          context 'and the const node is single constant without cbase' do
+            let(:position) { { line: 9, character: 15 } }
+            let(:text_edit_range) { { start: { line: 9, character: 6 }, end: { line: 9, character: 28 } } }
 
-          it 'returns infomation including appropriate labels' do
-            expect(subject).to be_a(LSP::Interface::CompletionList)
-            expect(subject.is_incomplete).to be_falsy
-            expect(subject.items).to include(
-              have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
-            )
+            it 'returns infomation including appropriate labels' do
+              expect(subject).to be_a(LSP::Interface::CompletionList)
+              expect(subject.is_incomplete).to be_falsy
+              expect(subject.items).to include(
+                have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+              )
+            end
+          end
+
+          context 'and the const node is single constant with cbase which does not exist' do
+            let(:position) { { line: 10, character: 15 } }
+
+            it 'returns empty candidates' do
+              expect(subject).to be_falsy
+            end
+          end
+
+          context 'and the const node is single constant with cbase' do
+            let(:position) { { line: 11, character: 15 } }
+            let(:text_edit_range) { { start: { line: 11, character: 8 }, end: { line: 11, character: 19 } } }
+
+            it 'returns infomation including appropriate labels' do
+              expect(subject).to be_a(LSP::Interface::CompletionList)
+              expect(subject.is_incomplete).to be_falsy
+              expect(subject.items).to include(
+                have_attributes(label: 'YodaFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+              )
+            end
+          end
+
+          context 'and the const node is single constant with cbase' do
+            let(:position) { { line: 12, character: 30 } }
+            let(:text_edit_range) { { start: { line: 12, character: 19 }, end: { line: 12, character: 41 } } }
+
+            it 'returns infomation including appropriate labels' do
+              expect(subject).to be_a(LSP::Interface::CompletionList)
+              expect(subject.is_incomplete).to be_falsy
+              expect(subject.items).to include(
+                have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+              )
+            end
+          end
+
+          context 'and there are constants with the common prefix of the const name but in different namespace' do
+            let(:position) { { line: 13, character: 23 } }
+            let(:text_edit_range) { { start: { line: 13, character: 19 }, end: { line: 13, character: 34 } } }
+
+            it 'returns candidates of constants without ones in different namespace' do
+              expect(subject).to be_a(LSP::Interface::CompletionList)
+              expect(subject.is_incomplete).to be_falsy
+              expect(subject.items).to contain_exactly(
+                have_attributes(label: 'YodaInnerModule', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+              )
+            end
           end
         end
 
-        context 'and the const node is single constant with cbase which does not exist' do
-          let(:position) { { line: 10, character: 15 } }
+        context 'and the cursor is after cbase' do
+          let(:position) { { line: 11, character: 8 } }
+          let(:text_edit_range) { { start: { line: 11, character: 8 }, end: { line: 11, character: 8 } } }
 
-          it 'returns empty candidates' do
-            expect(subject).to be_falsy
-          end
-        end
-
-        context 'and the const node is single constant with cbase' do
-          let(:position) { { line: 11, character: 15 } }
-          let(:text_edit_range) { { start: { line: 11, character: 8 }, end: { line: 11, character: 19 } } }
-
-          it 'returns infomation including appropriate labels' do
+          it 'returns candidates under Object' do
             expect(subject).to be_a(LSP::Interface::CompletionList)
             expect(subject.is_incomplete).to be_falsy
             expect(subject.items).to include(
@@ -141,29 +182,19 @@ RSpec.describe Yoda::Server::CompletionProvider do
           end
         end
 
-        context 'and the const node is single constant with cbase' do
-          let(:position) { { line: 12, character: 30 } }
-          let(:text_edit_range) { { start: { line: 12, character: 19 }, end: { line: 12, character: 41 } } }
+        context 'and the cursor is after double colons' do
+          context 'and the const node is single constant without cbase' do
+            let(:position) { { line: 12, character: 19 } }
+            let(:text_edit_range) { { start: { line: 12, character: 19 }, end: { line: 12, character: 19 } } }
 
-          it 'returns infomation including appropriate labels' do
-            expect(subject).to be_a(LSP::Interface::CompletionList)
-            expect(subject.is_incomplete).to be_falsy
-            expect(subject.items).to include(
-              have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
-            )
-          end
-        end
-
-        context 'and there are constants with the common prefix of the const name but in different namespace' do
-          let(:position) { { line: 13, character: 23 } }
-          let(:text_edit_range) { { start: { line: 13, character: 19 }, end: { line: 13, character: 34 } } }
-
-          it 'returns candidates of constants without ones in different namespace' do
-            expect(subject).to be_a(LSP::Interface::CompletionList)
-            expect(subject.is_incomplete).to be_falsy
-            expect(subject.items).to contain_exactly(
-              have_attributes(label: 'YodaInnerModule', text_edit: have_attributes(range: have_attributes(text_edit_range))),
-            )
+            it 'returns candidates under YodaFixture' do
+              expect(subject).to be_a(LSP::Interface::CompletionList)
+              expect(subject.is_incomplete).to be_falsy
+              expect(subject.items).to include(
+                have_attributes(label: 'ConstCompletionFixture', text_edit: have_attributes(range: have_attributes(text_edit_range))),
+              )
+              expect(subject.items).not_to include(have_attributes(label: 'YodaFixture'))
+            end
           end
         end
       end

--- a/spec/yoda/server/completion_provider_spec.rb
+++ b/spec/yoda/server/completion_provider_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Yoda::Server::CompletionProvider do
 
         context 'and the cursor is after cbase' do
           let(:position) { { line: 11, character: 8 } }
-          let(:text_edit_range) { { start: { line: 11, character: 8 }, end: { line: 11, character: 8 } } }
+          let(:text_edit_range) { { start: { line: 11, character: 6 }, end: { line: 11, character: 8 } } }
 
           it 'returns candidates under Object' do
             expect(subject).to be_a(LSP::Interface::CompletionList)
@@ -185,7 +185,7 @@ RSpec.describe Yoda::Server::CompletionProvider do
         context 'and the cursor is after double colons' do
           context 'and the const node is single constant without cbase' do
             let(:position) { { line: 12, character: 19 } }
-            let(:text_edit_range) { { start: { line: 12, character: 19 }, end: { line: 12, character: 19 } } }
+            let(:text_edit_range) { { start: { line: 12, character: 17 }, end: { line: 12, character: 19 } } }
 
             it 'returns candidates under YodaFixture' do
               expect(subject).to be_a(LSP::Interface::CompletionList)

--- a/spec/yoda/store/query/find_constant_spec.rb
+++ b/spec/yoda/store/query/find_constant_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe Yoda::Store::Query::FindConstant do
         expect(subject).not_to be
       end
     end
+
+    context 'with cbase string is given' do
+      let(:name) { '::' }
+
+      it 'returns the specified module' do
+        expect(subject).to be_a(Yoda::Store::Objects::ClassObject)
+        expect(subject.path).to eq('Object')
+      end
+    end
+
+    context 'with cbase string is given' do
+      let(:name) { Yoda::Model::Path.new('::') }
+
+      it 'returns the specified module' do
+        expect(subject).to be_a(Yoda::Store::Objects::ClassObject)
+        expect(subject.path).to eq('Object')
+      end
+    end
   end
 
   describe '#select_with_prefix' do

--- a/yoda.gemspec
+++ b/yoda.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'yard', '~> 0.9.11'
   spec.add_dependency 'parslet', '~> 1.8'
   spec.add_dependency 'parser', '~> 2.0'
-  spec.add_dependency 'language_server-protocol', '~> 0.5'
+  spec.add_dependency 'language_server-protocol', '~> 3.7.0.0'
   spec.add_dependency 'leveldb', '~> 0.1.9'
   spec.add_dependency 'lmdb', '~> 0.4.8'
   spec.add_dependency 'ruby-progressbar'


### PR DESCRIPTION
## WHAT

- Constant Completion just after `::`
   - Show all constants defined in the namespace
- Use proper `CompletionItemKind` for candidates of constant completion
- Update dependency versions (https://github.com/tomoasleep/yoda/commit/6e694d23d6cc0bac409394408b79957d3ee96b28)
  