### PR TITLE
Show progress of initialization

### DIFF
--- a/client/atom/main.js
+++ b/client/atom/main.js
@@ -7,6 +7,26 @@ class YodaClient extends AutoLanguageClient {
     super()
   }
 
+  preInitialization(connection) {
+    connection.onTelemetryEvent(({ type, phase, message }) => {
+      if (!this.busySignalService) { return; }
+      if (type != 'initialization') { return; }
+
+      if (this.initializationBusyMessage) {
+        this.initializationBusyMessage.setTitle(message);
+      } else {
+        this.initializationBusyMessage = this.busySignalService.reportBusy(message);
+      }
+    });
+  }
+
+  postInitialization(_server) {
+    if (this.initializationBusyMessage) {
+      this.initializationBusyMessage.dispose();
+      this.initializationBusyMessage = null;
+    }
+  }
+
   getGrammarScopes () { return ['source.ruby', 'source.rb', 'source.ruby.rails'] }
   getLanguageName () { return 'Ruby' }
   getServerName () { return 'Yoda' }

--- a/lib/yoda.rb
+++ b/lib/yoda.rb
@@ -1,6 +1,7 @@
 module Yoda
   require "yoda/version"
   require "yoda/logger"
+  require "yoda/instrument"
   require "yoda/commands"
   require "yoda/errors"
   require "yoda/evaluation"

--- a/lib/yoda/commands/setup.rb
+++ b/lib/yoda/commands/setup.rb
@@ -1,3 +1,5 @@
+require 'ruby-progressbar'
+
 module Yoda
   module Commands
     class Setup < Base
@@ -7,17 +9,23 @@ module Yoda
       # @return [true, false]
       attr_reader :force_build
 
+      # @return [Hash{ Symbol => ProgressBar }]
+      attr_reader :bars
+
       # @param dir [String]
       def initialize(dir: nil, force_build: false)
         @dir = dir || Dir.pwd
         @force_build = force_build
+        @bars = {}
       end
 
       def run
         build_core_index
         if File.exist?(File.expand_path('Gemfile.lock', dir)) || force_build
           Logger.info 'Building index for the current project...'
-          force_build ? project.rebuild_cache(progress: true) : project.build_cache(progress: true)
+          Instrument.instance.hear(initialization_progress: method(:on_progress), registry_dump: method(:on_progress)) do
+            force_build ? project.rebuild_cache : project.build_cache
+          end
         else
           Logger.info 'Skipped building project index because Gemfile.lock is not exist for the current dir'
         end
@@ -31,6 +39,12 @@ module Yoda
 
       def build_core_index
         Store::Actions::BuildCoreIndex.run unless Store::Actions::BuildCoreIndex.exists?
+      end
+
+      def on_progress(phase: :save_keys, index: nil, length: nil, **params)
+        return unless index
+        bar = bars[phase] ||= ProgressBar.create(format: "%t: %c/%C |%w>%i| %e ", title: phase.to_s.gsub('_', ' '), starting_at: index, total: length)
+        bar.progress = index if index <= bar.total
       end
     end
   end

--- a/lib/yoda/instrument.rb
+++ b/lib/yoda/instrument.rb
@@ -1,0 +1,113 @@
+module Yoda
+  class Instrument
+    class Subscription
+      # @return [Instrument]
+      attr_reader :instrument
+
+      # @return [String]
+      attr_reader :name
+
+      # @return [#call]
+      attr_reader :callback
+
+      # @param instrument [Instrument]
+      # @param name [String]
+      # @param callback [#call]
+      def initialize(instrument:, name:, callback:)
+        @instrument = instrument
+        @name = name
+        @callback = callback
+      end
+
+      def unsubscribe
+        instrument.unsubscribe(self)
+      end
+
+      def call(params)
+        callback.call(params)
+      end
+    end
+
+    class Progress
+      # @return [Integer]
+      attr_reader :length, :index
+
+      # @return [#call]
+      attr_reader :callback
+
+      # @param length [Integer]
+      # @param callback [#call]
+      def initialize(length, &callback)
+        @length = length
+        @index = 0
+        @callback = callback
+        call
+      end
+
+      def increment
+        @index += 1
+        call
+      end
+
+      def call
+        callback.call(length: length, index: index)
+      end
+    end
+
+    # @return [Array<Subscription>]
+    attr_reader :subscriptions
+
+    # @return [Instrument]
+    def self.instance
+      @instance ||= new
+    end
+
+    def initialize
+      @subscriptions = []
+    end
+
+    # Add subscriptions and eval the given block. these subscriptions are unsubscribed after the block.
+    # @param subscription_hash [Hash{ Symbol, String => #call }]
+    def hear(subscription_hash = {})
+      subscriptions = subscription_hash.map { |key, value| subscribe(key, &value) }
+      value = yield
+      subscriptions.each(&:unsubscribe)
+      value
+    end
+
+    # @param name [String, Symbol]
+    # @param callback [#call]
+    # @return [Subsctiption]
+    def subscribe(name, &callback)
+      Subscription.new(instrument: self, name: name, callback: callback).tap { |subscription| subscriptions.push(subscription) }
+    end
+
+    # @param name [String]
+    # @param [String]
+    def emit(name, params)
+      Logger.trace("#{name}: #{params}")
+      subscriptions.select { |subscription| subscription.name === name }.each { |subscription| subscription.call(params) }
+    end
+
+    # @param subscription [Subscription]
+    def unsubscribe(subscription)
+      subscriptions.delete(subscription)
+    end
+
+    # @!group event_name
+
+    # @param phase [Symbol]
+    # @param message [String]
+    # @param index [Integer, nil]
+    # @param length [Integer, nil]
+    def initialization_progress(phase:, message:, index: nil, length: nil)
+      emit(:initialization_progress, phase: phase, message: message, index: index, length: length)
+    end
+
+    # @param index [Integer, nil]
+    # @param length [Integer, nil]
+    def registry_dump(index: nil, length: nil)
+      emit(:registry_dump, index: index, length: length)
+    end
+  end
+end

--- a/lib/yoda/logger.rb
+++ b/lib/yoda/logger.rb
@@ -23,7 +23,7 @@ module Yoda
         define_method(level) do |content, tag: nil|
           return unless public_send("allow_#{level}?")
           prefix = "[#{level}]#{tag ? ' (' + tag + ')' : '' } "
-          io.puts(prefix + content.split("\n").join(prefix))
+          io.puts(prefix + content.to_s.split("\n").join(prefix))
         end
 
         define_method("allow_#{level}?") do

--- a/lib/yoda/logger.rb
+++ b/lib/yoda/logger.rb
@@ -2,11 +2,11 @@ require 'forwardable'
 
 module Yoda
   class Logger
-    LOG_LEVELS = %i(debug info warn error fatal).freeze
+    LOG_LEVELS = %i(trace debug info warn error fatal).freeze
 
     class << self
       extend Forwardable
-      def_delegators :instance, *%i(pipeline debug info warn error fatal log_level allow_debug? allow_info? allow_warn? allow_error? allow_fatal? log_level=)
+      def_delegators :instance, *%i(pipeline trace debug info warn error fatal log_level allow_debug? allow_info? allow_warn? allow_error? allow_fatal? log_level=)
 
       # @return [Yoda::Logger]
       def instance

--- a/lib/yoda/server.rb
+++ b/lib/yoda/server.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 
 module Yoda
   class Server
+    require 'yoda/server/notifier'
     require 'yoda/server/completion_provider'
     require 'yoda/server/signature_provider'
     require 'yoda/server/hover_provider'
@@ -45,6 +46,11 @@ module Yoda
       @reader = LSP::Transport::Stdio::Reader.new
       @writer = LSP::Transport::Stdio::Writer.new
       @after_notifications = []
+    end
+
+    # @return [Notifier]
+    def notifier
+      @notifier ||= Notifier.new(self)
     end
 
     def run

--- a/lib/yoda/server.rb
+++ b/lib/yoda/server.rb
@@ -146,7 +146,7 @@ module Yoda
       @signature_provider = SignatureProvider.new(@session)
       @definition_provider = DefinitionProvider.new(@session)
 
-      (InitializationProvider.new(@session).provide || []).each { |notification| after_notifications.push(notification) }
+      (InitializationProvider.new(session: session, notifier: notifier).provide || []).each { |notification| after_notifications.push(notification) }
 
       LSP::Interface::InitializeResult.new(
         capabilities: LSP::Interface::ServerCapabilities.new(

--- a/lib/yoda/server/notifier.rb
+++ b/lib/yoda/server/notifier.rb
@@ -1,0 +1,61 @@
+module Yoda
+  class Server
+    class Notifier
+      # @param server [Server]
+      def initialize(server)
+        @server = server
+      end
+
+      # @param params [Hash]
+      def event(params)
+        server.send_notification(method: 'telemetry/event', params: params)
+      end
+
+      # @param type [String, Symbol]
+      # @param message [String]
+      def show_message(type:, message:)
+        server.send_notification(
+          method: 'window/showMessage',
+          params: LanguageServer::Protocol::Interface::ShowMessageParams.new(
+            type: message_type(type),
+            message: message,
+          )
+        )
+      end
+
+      # @param type [String, Symbol]
+      # @param message [String]
+      def log_message(type:, message:)
+        server.send_notification(
+          method: 'window/logMessage',
+          params: LanguageServer::Protocol::Interface::ShowMessageParams.new(
+            type: message_type(type),
+            message: message,
+          )
+        )
+      end
+
+      private
+
+      # @param type [String, Symbol]
+      def message_type(type)
+        case type.to_sym
+        when :error
+          LanguageServer::Protocol::Constant::MessageType::ERROR
+        when :warning
+          LanguageServer::Protocol::Constant::MessageType::WARNING
+        when :info
+          LanguageServer::Protocol::Constant::MessageType::INFO
+        when :log
+          LanguageServer::Protocol::Constant::MessageType::LOG
+        else
+          Logger.warn("#{type} is not valie message type")
+          LanguageServer::Protocol::Constant::MessageType::INFO
+        end
+      end
+
+      # @return [Server]
+      attr_reader :server
+    end
+  end
+end

--- a/lib/yoda/server/session.rb
+++ b/lib/yoda/server/session.rb
@@ -32,7 +32,10 @@ module Yoda
       end
 
       def setup
-        Store::Actions::BuildCoreIndex.run unless Store::Actions::BuildCoreIndex.exists?
+        unless Store::Actions::BuildCoreIndex.exists?
+          Instrument.instance.initialization_progress(phase: :core, message: 'Downloading and building core index')
+          Store::Actions::BuildCoreIndex.run
+        end
         project.build_cache
       end
 

--- a/lib/yoda/store/actions/read_project_files.rb
+++ b/lib/yoda/store/actions/read_project_files.rb
@@ -14,7 +14,15 @@ module Yoda
         end
 
         def run
-          project_files.each { |file| ReadFile.run(registry, file) }
+          files = project_files
+          progress = Instrument::Progress.new(files.length) do |index:, length:|
+            Instrument.instance.initialization_progress(phase: :load_project_files, message: "Loading current project files (#{index} / #{length})", index: index, length: length)
+          end
+
+          files.each do |file|
+            ReadFile.run(registry, file)
+            progress.increment
+          end
         end
 
         private

--- a/lib/yoda/store/adapters/base.rb
+++ b/lib/yoda/store/adapters/base.rb
@@ -52,6 +52,12 @@ module Yoda
         def clear
           fail NotImplementedError
         end
+
+        # @param data [Enumerator<(String, Object)>]
+        # @param bar [#increment, nil]
+        # @abstract
+        def batch_write(data, bar)
+        end
       end
     end
   end

--- a/lib/yoda/store/adapters/leveldb_adapter.rb
+++ b/lib/yoda/store/adapters/leveldb_adapter.rb
@@ -38,7 +38,7 @@ module Yoda
         end
 
         # @param data [Enumerator<(String, Object)>]
-        # @param bar [ProgressBar, nil]
+        # @param bar [#increment, nil]
         def batch_write(data, bar)
           data.each do |(k, v)|
             @db.put(k, v)

--- a/lib/yoda/store/adapters/lmdb_adapter.rb
+++ b/lib/yoda/store/adapters/lmdb_adapter.rb
@@ -33,7 +33,7 @@ module Yoda
         end
 
         # @param data [Enumerator<(String, Object)>]
-        # @param bar [ProgressBar, nil]
+        # @param bar [#increment, nil]
         def batch_write(data, bar)
           env = LMDB.new(@path, mapsize: @env.info[:mapsize], writemap: true, mapasync: true, nosync: true)
           db = env.database('main', create: true)

--- a/lib/yoda/store/adapters/memory_adapter.rb
+++ b/lib/yoda/store/adapters/memory_adapter.rb
@@ -33,7 +33,7 @@ module Yoda
         end
 
         # @param data [Enumerator<(String, Object)>]
-        # @param bar [ProgressBar, nil]
+        # @param bar [#increment, nil]
         def batch_write(data, bar)
           data.each do |(k, v)|
             put(k, v)

--- a/lib/yoda/store/project.rb
+++ b/lib/yoda/store/project.rb
@@ -31,17 +31,17 @@ module Yoda
       end
 
       # @return [Array<BaseError>]
-      def build_cache(progress: false)
+      def build_cache
         setup
         loader = LibraryDocLoader.build_for(self)
-        loader.run(progress: progress)
+        loader.run
         load_project_files
         loader.errors
       end
 
-      def rebuild_cache(progress: false)
+      def rebuild_cache
         clear
-        build_cache(progress: progress)
+        build_cache
       end
 
       def yoda_dir
@@ -57,6 +57,7 @@ module Yoda
 
       def load_project_files
         Logger.debug('Loading current project files...')
+        Instrument.instance.initialization_progress(phase: :load_project_files, message: 'Loading current project files')
         Actions::ReadProjectFiles.new(registry, root_path).run
       end
 

--- a/lib/yoda/store/project/library_doc_loader.rb
+++ b/lib/yoda/store/project/library_doc_loader.rb
@@ -67,6 +67,7 @@ module Yoda
         # @param bundle_status [Objects::ProjectStatus::BundleStatus]
         # @return [Objects::ProjectStatus::BundleStatus]
         def import_deps(bundle_status)
+          Instrument.instance.initialization_progress(phase: :load_core, message: 'Loading core index')
           bundle_status = import_core(bundle_status) unless bundle_status.std_status.core_present?
           bundle_status = import_std(bundle_status) unless bundle_status.std_status.std_present?
           import_gems(bundle_status)
@@ -91,16 +92,20 @@ module Yoda
         # @param bundle_status [Objects::ProjectStatus::BundleStatus]
         # @return [Objects::ProjectStatus::BundleStatus]
         def import_gems(bundle_status)
-          gem_statuses = bundle_status.gem_statuses.map do |gem_status|
-            if gem_status.present?
-              gem_status
-            else
-              result = Actions::ImportGem.run(registry: registry, gem_name: gem_status.name, gem_version: gem_status.version)
-              errors.push(GemImportError.new(name: gem_status.name, version: gem_status.version)) unless result
-              gem_status.derive(present: result)
-            end
+          present_gem_statuses, absent_gem_statuses = bundle_status.gem_statuses.partition { |gem_status| gem_status.present? }
+
+          progress = Instrument::Progress.new(absent_gem_statuses.length) do |index:, length:|
+            Instrument.instance.initialization_progress(phase: :load_gems, message: "Loading gems (#{index} / #{length})", index: index, length: length)
           end
-          bundle_status.derive(gem_statuses: gem_statuses)
+
+          new_gem_statuses = absent_gem_statuses.map do |gem_status|
+            result = Actions::ImportGem.run(registry: registry, gem_name: gem_status.name, gem_version: gem_status.version)
+            progress.increment
+            errors.push(GemImportError.new(name: gem_status.name, version: gem_status.version)) unless result
+            gem_status.derive(present: result)
+          end
+
+          bundle_status.derive(gem_statuses: present_gem_statuses + new_gem_statuses)
         end
       end
     end

--- a/lib/yoda/store/project/library_doc_loader.rb
+++ b/lib/yoda/store/project/library_doc_loader.rb
@@ -44,9 +44,9 @@ module Yoda
           @errors = []
         end
 
-        def run(progress: false)
+        def run
           project_status = registry.project_status || Objects::ProjectStatus.initial_build(specs: gem_specs)
-          new_bundle_status = update_bundle(project_status.bundle, progress: progress)
+          new_bundle_status = update_bundle(project_status.bundle)
           registry.save_project_status(project_status.derive(bundle: new_bundle_status))
         end
 
@@ -54,11 +54,11 @@ module Yoda
 
         # @param bundle_status [Objects::ProjectStatus::BundleStatus]
         # @return [Objects::ProjectStatus::BundleStatus]
-        def update_bundle(bundle_status, progress: false)
+        def update_bundle(bundle_status)
           unless bundle_status.all_present?
             Logger.info 'Constructing database for the current project.'
             bundle_status = import_deps(bundle_status)
-            registry.compress_and_save(progress: progress)
+            registry.compress_and_save
           end
           bundle_status
         end


### PR DESCRIPTION
## What

- Introduce internal notification system (`Yoda::Instrument`)
   - Refactor progress bar to use `Yoda::Instrument`
- Show progress of initialization (currently for Atom only)
   - These progresses are delivered as `telemetry/event` (https://microsoft.github.io/language-server-protocol/specification#telemetry_event)

<img width="321" alt="2018-08-26 15 31 12" src="https://user-images.githubusercontent.com/1477130/44625466-63fa8480-a945-11e8-96a0-3c8bcf0b5501.png">
