### PR TITLE
Show current node on hover helper

### DIFF
--- a/lib/yoda/evaluation/current_node_explain.rb
+++ b/lib/yoda/evaluation/current_node_explain.rb
@@ -1,5 +1,6 @@
 module Yoda
   module Evaluation
+    # CurrentNodeExplain shows help for the current node.
     class CurrentNodeExplain
       # @return [Store::Registry]
       attr_reader :registry

--- a/lib/yoda/evaluation/signature_discovery.rb
+++ b/lib/yoda/evaluation/signature_discovery.rb
@@ -1,5 +1,7 @@
 module Yoda
   module Evaluation
+    # SignatureDiscovery infers method candidates for the nearest send node and specify the number of index of these parameters.
+    # SignatureDiscovery shows help for the current parameter of method candidates.
     class SignatureDiscovery
       # @return [Store::Registry]
       attr_reader :registry

--- a/lib/yoda/model/descriptions.rb
+++ b/lib/yoda/model/descriptions.rb
@@ -5,6 +5,7 @@ module Yoda
       require 'yoda/model/descriptions/function_description'
       require 'yoda/model/descriptions/value_description'
       require 'yoda/model/descriptions/word_description'
+      require 'yoda/model/descriptions/node_description'
     end
   end
 end

--- a/lib/yoda/model/descriptions/node_description.rb
+++ b/lib/yoda/model/descriptions/node_description.rb
@@ -1,0 +1,46 @@
+require 'unparser'
+
+module Yoda
+  module Model
+    module Descriptions
+      class NodeDescription < Base
+        # @return [::Parser::AST::Node]
+        attr_reader :node
+
+        # @return [Typing::Traces::Base]
+        attr_reader :trace
+
+        # @param node  [::Parser::AST::Node]
+        # @param trace [Typing::Traces::Base]
+        def initialize(node, trace)
+          @node = node
+          @trace = trace
+        end
+
+        # @return [String]
+        def title
+          node_body
+        end
+
+        # @return [String]
+        def sort_text
+          node_body
+        end
+
+        # @return [String]
+        def to_markdown
+          <<~EOS
+          #{node_body.gsub("\n", ";")}: #{trace.type}
+          EOS
+        end
+
+        private
+
+        # @return [String]
+        def node_body
+          @node_body ||= Unparser.unparse(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/yoda/model/node_signature.rb
+++ b/lib/yoda/model/node_signature.rb
@@ -1,7 +1,12 @@
 module Yoda
   module Model
     class NodeSignature
-      attr_reader :node, :trace
+      # @return [::Parser::AST::Node]
+      attr_reader :node
+
+      # @return [Typing::Traces::Base]
+      attr_reader :trace
+
       # @param node  [::Parser::AST::Node]
       # @param trace [Typing::Traces::Base]
       def initialize(node, trace)
@@ -16,6 +21,16 @@ module Yoda
 
       # @return [Array<Descriptions::Base>]
       def descriptions
+        [top_description, *type_descriptions]
+      end
+
+      # @return [Descriptions::NodeDescription]
+      def top_description
+        Descriptions::NodeDescription.new(node, trace)
+      end
+
+      # @return [Array<Descriptions::Base>]
+      def type_descriptions
         case trace
         when Typing::Traces::Send
           trace.functions.map { |function| Descriptions::FunctionDescription.new(function) }.take(1)

--- a/lib/yoda/store/actions/import_core_library.rb
+++ b/lib/yoda/store/actions/import_core_library.rb
@@ -12,6 +12,7 @@ module Yoda
           end
         end
 
+        # @param registry [Registry]
         def initialize(registry)
           @registry = registry
         end

--- a/spec/yoda/server/hover_provider_spec.rb
+++ b/spec/yoda/server/hover_provider_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns completion for `self` variable' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**String**'))
+        expect(subject.contents).to match [be_start_with("str: String"), be_start_with('**String**')]
         expect(subject.range).to have_attributes(start: { line: 7, character: 6 }, end: { line: 7, character: 9 })
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns completion for `self` variable' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**YodaFixture::Sample3.class**'))
+        expect(subject.contents).to match [be_start_with("Sample3: YodaFixture::Sample3.module"), be_start_with('**YodaFixture::Sample3.class**')]
         expect(subject.range).to have_attributes(start: { line: 13, character: 6 }, end: { line: 13, character: 13 })
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns the description of the calling method' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**YodaFixture::Sample3.class_method1(String str): any**'))
+        expect(subject.contents).to match [be_start_with('Sample3.class_method1(""): any'), be_start_with('**YodaFixture::Sample3.class_method1(String str): any**')]
         expect(subject.range).to have_attributes(start: { line: 17, character: 6 }, end: { line: 17, character: 31 })
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns the description of the calling method' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**String#piyo: Integer**'))
+        expect(subject.contents).to match [be_start_with('str.piyo: Integer'), be_start_with('**String#piyo: Integer**')]
         expect(subject.range).to have_attributes(start: { line: 8, character: 8 }, end: { line: 8, character: 16 })
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns the description of the calling method' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**String#piyo: Integer**'))
+        expect(subject.contents).to match [be_start_with('str.piyo: Integer'), be_start_with('**String#piyo: Integer**')]
         expect(subject.range).to have_attributes(start: { line: 8, character: 8 }, end: { line: 8, character: 16 })
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns the description of the calling method' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**String#bytesize: Integer**'))
+        expect(subject.contents).to match [be_start_with('str.bytesize: Integer'), be_start_with('**String#bytesize: Integer**')]
         expect(subject.range).to have_attributes(start: { line: 9, character: 8 }, end: { line: 9, character: 20 })
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Yoda::Server::HoverProvider do
 
       it 'returns the description of the calling method' do
         expect(subject).to be_a(LSP::Interface::Hover)
-        expect(subject.contents).to contain_exactly(be_start_with('**String.class**'))
+        expect(subject.contents).to match [be_start_with('::String: String.module'), be_start_with('**String.class**')]
         expect(subject.range).to have_attributes(start: { line: 13, character: 8 }, end: { line: 13, character: 16 })
       end
     end

--- a/yoda-language-server.gemspec
+++ b/yoda-language-server.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 0.20.0'
   spec.add_dependency 'parslet', '~> 1.8'
   spec.add_dependency 'parser', '~> 2.0'
+  spec.add_dependency 'unparser', '~> 0.2.6'
   spec.add_dependency 'language_server-protocol', '~> 3.7.0.0'
   spec.add_dependency 'leveldb', '~> 0.1.9'
   spec.add_dependency 'lmdb', '~> 0.4.8'


### PR DESCRIPTION
## WHAT

Show current node with inferred type on hover help.
(Existing helps for the method and the type appended after the current node help.)

<img width="545" alt="2018-08-28 21 26 20" src="https://user-images.githubusercontent.com/1477130/44722767-0ca51180-ab09-11e8-81c1-b064234919ed.png">
