### PR TITLE
Show busy signal on hover, completion, signature help, go-to-definition

### DIFF
--- a/client/atom/main.js
+++ b/client/atom/main.js
@@ -2,28 +2,27 @@ const { AutoLanguageClient } = require('atom-languageclient')
 const { spawn } = require('child_process')
 const { resolve } = require('path')
 
+const busyMessages = {
+  text_document_hover: 'Preparing hover help',
+  text_document_signature_help: 'Preparing signature help',
+  text_document_completion: 'Completing',
+  text_document_definition: 'Finding definition',
+};
+
 class YodaClient extends AutoLanguageClient {
   constructor() {
     super()
+    this.busyHandlers = {};
   }
 
   preInitialization(connection) {
-    connection.onTelemetryEvent(({ type, phase, message }) => {
-      if (!this.busySignalService) { return; }
-      if (type != 'initialization') { return; }
-
-      if (this.initializationBusyMessage) {
-        this.initializationBusyMessage.setTitle(message);
-      } else {
-        this.initializationBusyMessage = this.busySignalService.reportBusy(message);
-      }
-    });
+    connection.onTelemetryEvent((event) => this.handleTelemetryEvent(event));
   }
 
   postInitialization(_server) {
-    if (this.initializationBusyMessage) {
-      this.initializationBusyMessage.dispose();
-      this.initializationBusyMessage = null;
+    if (this.busyHandlers.initialization) {
+      this.busyHandlers.initialization.dispose();
+      this.busyHandlers.initialization = null;
     }
   }
 
@@ -51,6 +50,44 @@ class YodaClient extends AutoLanguageClient {
   _launchYoda(projectPath) {
     const commandOptions = { cwd: projectPath };
     return spawn(this.getServerPath(), ['server'], commandOptions);
+  }
+
+  handleTelemetryEvent(eventBody) {
+    if (!this.busySignalService || !eventBody) { return; }
+    switch (eventBody.type) {
+      case 'initialization':
+        return this.handleInitializationEvent(eventBody);
+      case 'text_document_hover':
+      case 'text_document_completion':
+      case 'text_document_signature_help':
+      case 'text_document_completion':
+        return this.handleBusyEvent(eventBody.type, eventBody);
+      default:
+    }
+  }
+
+  handleInitializationEvent({ phase, message }) {
+    if (this.busyHandlers.initialization) {
+      this.busyHandlers.initialization.setTitle(message);
+    } else {
+      this.busyHandlers.initialization = this.busySignalService.reportBusy(message);
+    }
+  }
+
+  handleBusyEvent(handlerName, { phase, message }) {
+    switch (phase) {
+      case 'begin':
+        if (!this.busyHandlers[handlerName]) {
+          this.busyHandlers[handlerName] = this.busySignalService.reportBusy("(Yoda) " + busyMessages[handlerName]);
+        }
+        break;
+      case 'end':
+        if (this.busyHandlers[handlerName]) {
+          this.busyHandlers[handlerName].dispose();
+          this.busyHandlers[handlerName] = null;
+        }
+        break;
+    }
   }
 }
 

--- a/lib/yoda/server.rb
+++ b/lib/yoda/server.rb
@@ -213,28 +213,36 @@ module Yoda
         uri = params[:text_document][:uri]
         position = params[:position]
 
-        completion_provider&.complete(uri, position)
+        notifier.busy(type: :text_document_completion) do
+          completion_provider&.complete(uri, position)
+        end
       end
 
       def handle_text_document_hover(params)
         uri = params[:text_document][:uri]
         position = params[:position]
 
-        hover_provider&.request_hover(uri, position)
+        notifier.busy(type: :text_document_hover) do
+          hover_provider&.request_hover(uri, position)
+        end
       end
 
       def handle_text_document_signature_help(params)
         uri = params[:text_document][:uri]
         position = params[:position]
 
-        signature_provider&.provide(uri, position)
+        notifier.busy(type: :text_document_signature_help) do
+          signature_provider&.provide(uri, position)
+        end
       end
 
       def handle_text_document_definition(params)
         uri = params[:text_document][:uri]
         position = params[:position]
 
-        definition_provider&.provide(uri, position)
+        notifier.busy(type: :text_document_definition) do
+          definition_provider&.provide(uri, position)
+        end
       end
     end
     include TextDocument

--- a/lib/yoda/server/hover_provider.rb
+++ b/lib/yoda/server/hover_provider.rb
@@ -1,6 +1,7 @@
 module Yoda
   class Server
     class HoverProvider
+      # @return [Session]
       attr_reader :session
 
       # @param session [Session]

--- a/lib/yoda/server/notifier.rb
+++ b/lib/yoda/server/notifier.rb
@@ -6,6 +6,14 @@ module Yoda
         @server = server
       end
 
+      # @param type [Symbol]
+      def busy(type:)
+        event(type: type, phase: :begin)
+        yield
+      ensure
+        event(type: type, phase: :end)
+      end
+
       # @param params [Hash]
       def event(params)
         server.send_notification(method: 'telemetry/event', params: params)

--- a/lib/yoda/store/project/library_doc_loader.rb
+++ b/lib/yoda/store/project/library_doc_loader.rb
@@ -58,6 +58,7 @@ module Yoda
           unless bundle_status.all_present?
             Logger.info 'Constructing database for the current project.'
             bundle_status = import_deps(bundle_status)
+            Instrument.instance.initialization_progress(phase: :save, message: 'Saving registry')
             registry.compress_and_save
           end
           bundle_status


### PR DESCRIPTION
## WHAT

Show busy signal on waiting for hover, completion, signature help and go-to-definition as initialization. (currently only Atom plugin shows)

(↓ Sample for busy signal)

<img width="321" alt="2018-08-26 15 31 12" src="https://user-images.githubusercontent.com/1477130/44723546-4414bd80-ab0b-11e8-82c1-6f314f79ade8.png">
