### PR TITLE
Improve patch calculation

### DIFF
--- a/lib/yoda/store.rb
+++ b/lib/yoda/store.rb
@@ -5,6 +5,7 @@ module Yoda
     require 'yoda/store/actions'
     require 'yoda/store/adapters'
     require 'yoda/store/project'
+    require 'yoda/store/registry_cache'
     require 'yoda/store/registry'
     require 'yoda/store/objects'
     require 'yoda/store/query'

--- a/lib/yoda/store/objects/patch.rb
+++ b/lib/yoda/store/objects/patch.rb
@@ -9,9 +9,10 @@ module Yoda
         attr_reader :registry
 
         # @param id [String]
-        def initialize(id)
+        # @param  [Array[Addressable], nil]
+        def initialize(id, contents = nil)
           @id = id
-          @registry = Hash.new
+          @registry = (contents || []).map { |content| [content.address.to_sym, content] }.to_h
         end
 
         # @param addressable [Addressable]

--- a/lib/yoda/store/objects/patch_set.rb
+++ b/lib/yoda/store/objects/patch_set.rb
@@ -1,78 +1,110 @@
+require 'set'
+
 module Yoda
   module Store
     module Objects
       # PatchSet manages patch updates and patch outdates.
       # Besides, this class provides api to modify objects by using owning patches.
       class PatchSet
-        # @return [{ Symbol => Array<Symbol> }]
-        attr_reader :address_index
+        class AddressIndex
+          def initialize
+            @index = Hash.new
+          end
 
-        # @return [{ Symbol => Patch }]
-        attr_reader :patches
+          # @param address [Symbol]
+          # @return [Set<Symbol>]
+          def get(address)
+            index[address] ||= Set.new
+          end
+
+          # @return [Set<Symbol>]
+          def keys
+            index.keys
+          end
+
+          # @param patch [Patch]
+          # @return [void]
+          def register(patch)
+            patch.keys.each do |key|
+              index[key.to_sym] ||= Set.new
+              index[key.to_sym].add(patch.id.to_sym)
+            end
+          end
+
+          # @param patch [Patch]
+          # @return [void]
+          def delete(patch)
+            patch.keys.each do |key|
+              (index[key.to_sym] || []).delete(patch.id.to_sym)
+            end
+          end
+
+          private
+          # @return [{ Symbol => Array<Symbol> }]
+          attr_reader :index
+        end
 
         def initialize
           @patches = Hash.new
-          @address_index = Hash.new
+          @address_index = AddressIndex.new
         end
 
         # @param patch [Patch]
         # @return [void]
         def register(patch)
-          register_to_index(patch)
+          address_index.register(patch)
           patches[patch.id.to_sym] = patch
         end
 
         # @param id [String, Symbol]
         def delete(id)
+          if patch = patches[id.to_sym]
+            address_index.delete(patch)
+          end
           patches.delete(id.to_sym)
         end
 
         # @param object [Addressable]
         # @return [Addressable]
         def patch(object)
-          check_outdated_index(object.address.to_sym)
-          objects_in_patch = (address_index[object.address.to_sym] || []).map { |patch_id| patches[patch_id].find(object.address.to_sym) }
+          objects_in_patch = get_patches(object.address)
           Merger.new([object, *objects_in_patch]).merged_instance
         end
 
         # @param address [String, Symbol]
         # @return [Addressable, nil]
         def find(address)
-          check_outdated_index(address.to_sym)
-          if (patch_ids = address_index[address.to_sym] || []).empty?
+          if (patches = get_patches(address)).empty?
             nil
           else
-            objects = patch_ids.map { |id| patches[id].find(address.to_sym) }
-            Merger.new(objects).merged_instance
+            Merger.new(patches).merged_instance
           end
         end
 
         # @return [Array<Symbol>]
         def keys
-          address_index.keys
+          address_index.keys.to_a
         end
 
         # @param address [String, Symbol]
         # @return [true, false]
         def has_key?(address)
-          check_outdated_index(address.to_sym)
-          address_index[address.to_sym] && !address_index[address.to_sym].empty?
+          !address_index.get(address.to_sym).empty?
         end
 
         private
 
-        # @param patch [Patch]
-        # @return [void]
-        def register_to_index(patch)
-          patch.keys.each do |key|
-            address_index[key.to_sym] ||= []
-            address_index[key.to_sym].push(patch.id.to_sym)
-          end
-        end
+        # @return [AddressIndex]
+        attr_reader :address_index
 
-        # @param address [Symbol]
-        def check_outdated_index(address)
-          (address_index[address] || []).select! { |patch_id| patches[patch_id].has_key?(address) }
+        # @return [{ Symbol => Patch }]
+        attr_reader :patches
+
+        # @param address [String, Symbol]
+        # @return [Array<Patch>]
+        def get_patches(address)
+          patch_ids = address_index.get(address.to_sym)
+          patch_ids.map { |id| patches[id].find(address.to_sym) }
         end
       end
     end

--- a/lib/yoda/store/registry.rb
+++ b/lib/yoda/store/registry.rb
@@ -12,6 +12,7 @@ module Yoda
       def initialize(adapter = nil)
         @patch_set = Objects::PatchSet.new
         @adapter = adapter
+        @lock = Concurrent::ReentrantReadWriteLock.new
       end
 
       # @return [Objects::ProjectStatus, nil]
@@ -89,9 +90,7 @@ module Yoda
       attr_reader :patch_set
 
       # @return [Concurrent::ReentrantReadWriteLock]
-      def lock
-        @lock ||= Concurrent::ReentrantReadWriteLock.new
-      end
+      attr_reader :lock
 
       def keys
         Set.new(adapter&.keys.map(&:to_s) || []).union(patch_set.keys)

--- a/lib/yoda/store/registry_cache.rb
+++ b/lib/yoda/store/registry_cache.rb
@@ -1,0 +1,40 @@
+require 'concurrent'
+
+module Yoda
+  module Store
+    # Registry Cache is a cache layer for {Registry}.
+    # This class intended to reduce patch calculations of {PatchSet#patch}.
+    class RegistryCache
+      def initialize
+        @data = Concurrent::Map.new
+      end
+
+      # @param key [String, Symbol]
+      def fetch_or_calc(key)
+        if cache = data.get(key.to_sym)
+          return cache
+        end
+        yield.tap { |value| data.put_if_absent(key.to_sym, value) }
+      end
+
+      # @param key [String, Symbol]
+      def delete(key)
+        data.delete(key.to_sym)
+      end
+
+      def delete_all
+        data.clear
+      end
+
+      # @param patch [Objects::Patch]
+      def clear_from_patch(patch)
+        patch.keys.each { |key| delete(key) }
+      end
+
+      private
+
+      # @return [Concurrent::Map]
+      attr_reader :data
+    end
+  end
+end

--- a/spec/yoda/store/objects/patch_set_spec.rb
+++ b/spec/yoda/store/objects/patch_set_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+RSpec.describe Yoda::Store::Objects::PatchSet do
+  let(:patch_set) do
+    Yoda::Store::Objects::PatchSet.new.tap { |patch_set| patches.each { |patch| patch_set.register(patch) } }
+  end
+
+  describe '#find' do
+    subject { patch_set.find(key) }
+
+    describe 'instance method addresses' do
+      let(:patches) do
+        [
+          Yoda::Store::Objects::Patch.new(
+            'patch1',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                instance_method_addresses: ['Object#to_s'],
+              ),
+            ],
+          ),
+          Yoda::Store::Objects::Patch.new(
+            'patch2',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                instance_method_addresses: ['Object#id'],
+              ),
+            ],
+          ),
+          Yoda::Store::Objects::Patch.new(
+            'patch3',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                instance_method_addresses: ['Object#to_s', 'Object#to_a'],
+              ),
+            ],
+          ),
+        ]
+      end
+      let(:key) { 'Object' }
+
+      it 'merges' do
+        expect(subject).to be_a(Yoda::Store::Objects::ClassObject)
+        expect(subject.to_h).to include(
+          path: 'Object',
+          instance_method_addresses: contain_exactly('Object#to_s', 'Object#id', 'Object#to_a'),
+        )
+      end
+    end
+
+    describe 'tag list' do
+      let(:patches) do
+        [
+          Yoda::Store::Objects::Patch.new(
+            'patch1',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                tag_list: [Yoda::Store::Objects::Tag.new(tag_name: 'private')],
+              ),
+            ],
+          ),
+          Yoda::Store::Objects::Patch.new(
+            'patch2',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                tag_list: [Yoda::Store::Objects::Tag.new(tag_name: 'deprecated')],
+              ),
+            ],
+          ),
+          Yoda::Store::Objects::Patch.new(
+            'patch3',
+            [
+              Yoda::Store::Objects::ClassObject.new(
+                path: 'Object',
+                tag_list: [Yoda::Store::Objects::Tag.new(tag_name: 'abstract')],
+              ),
+            ],
+          ),
+        ]
+      end
+      let(:key) { 'Object' }
+
+      it 'merges' do
+        expect(subject).to be_a(Yoda::Store::Objects::ClassObject)
+        expect(subject.to_h).to include(
+          path: 'Object',
+          tag_list: contain_exactly(
+            Yoda::Store::Objects::Tag.new(tag_name: 'private'),
+            Yoda::Store::Objects::Tag.new(tag_name: 'deprecated'),
+            Yoda::Store::Objects::Tag.new(tag_name: 'abstract'),
+          ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT

- Tuning of patch implementation
   - Reduce Object Creation on Merger https://github.com/tomoasleep/yoda/commit/501b8bf7a7488ef5ab39c7046520ee43475557a4
   - Introduce Caches of `PatchSet#patch` https://github.com/tomoasleep/yoda/commit/dfdc51c16d912b366b8cfa8266757a453c3e7a10
- Add specs for PatchSet

## Comparison

Compared with `yoda infer`.
(`yoda infer` scans project files and infers the type of the given position.)

### master

```
~/.ghq/github.com/tomoasleep/yoda (master 867848b)
(ρ _-)ノ time ./exe/yoda infer lib/yoda/store/yard_importer.rb:19:196
warning: parser/current is loading parser/ruby25, which recognizes
warning: 2.5.1-compliant syntax, but you are running 2.5.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
def self.import(file, root_path: nil)
  store = YARD::RegistryStore.new
  store.load(file)
  root_path ||= File.expand_path("..", file)
  new(file, root_path: root_path).import(store.values).patch
end
Yoda::Store::Objects::Patch
       30.36 real        27.27 user         0.53 sys
```

### this branch

```
~/.ghq/github.com/tomoasleep/yoda (patch-tuning 501b8bf)
(ρ _-)ノ time ./exe/yoda infer lib/yoda/store/yard_importer.rb:19:196
warning: parser/current is loading parser/ruby25, which recognizes
warning: 2.5.1-compliant syntax, but you are running 2.5.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
def self.import(file, root_path: nil)
  store = YARD::RegistryStore.new
  store.load(file)
  root_path ||= File.expand_path("..", file)
  new(file, root_path: root_path).import(store.values).patch
end
Yoda::Store::Objects::Patch
        4.69 real         4.24 user         0.34 sys
```